### PR TITLE
Adjust user creation access and add date input masks

### DIFF
--- a/api/user_station_options.php
+++ b/api/user_station_options.php
@@ -1,0 +1,114 @@
+<?php
+declare(strict_types=1);
+header('Content-Type: application/json; charset=utf-8');
+header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+header('Pragma: no-cache');
+
+$ROOT = dirname(__DIR__);
+require_once $ROOT . '/lib/session.php';
+session_boot();
+require_once $ROOT . '/lib/db.php';
+require_once $ROOT . '/lib/auth.php';
+
+try {
+    $user = auth_user();
+    if (!$user) {
+        http_response_code(401);
+        echo json_encode(['ok' => false, 'error' => 'unauthorized']);
+        return;
+    }
+    $role = strtolower((string)($user['role'] ?? 'viewer'));
+    if ($role === 'viewer') {
+        http_response_code(403);
+        echo json_encode(['ok' => false, 'error' => 'forbidden']);
+        return;
+    }
+
+    $pdo = db();
+
+    $metaStations = [];
+    $hasEstaciones = $pdo->query("SHOW TABLES LIKE 'estaciones'")->fetchColumn();
+    if ($hasEstaciones) {
+        $stmt = $pdo->query("SELECT UPPER(TRIM(COALESCE(oaci,''))) AS oaci, COALESCE(nombre,'') AS nombre, COALESCE(region,'') AS region FROM estaciones WHERE oaci IS NOT NULL AND oaci <> ''");
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $oaci = strtoupper(trim((string)($row['oaci'] ?? '')));
+            if ($oaci === '') {
+                continue;
+            }
+            $metaStations[$oaci] = [
+                'oaci' => $oaci,
+                'nombre' => (string)($row['nombre'] ?? ''),
+                'region' => (string)($row['region'] ?? ''),
+            ];
+        }
+    }
+
+    if (!$metaStations) {
+        $fallback = $pdo->query("SELECT DISTINCT estacion FROM empleados WHERE estacion IS NOT NULL AND estacion <> ''");
+        foreach ($fallback->fetchAll(PDO::FETCH_COLUMN) as $id) {
+            $oaci = estacion_id_to_oaci((int)$id);
+            if (!$oaci) {
+                continue;
+            }
+            $metaStations[$oaci] = [
+                'oaci' => $oaci,
+                'nombre' => '',
+                'region' => '',
+            ];
+        }
+    }
+
+    if ($role === 'admin') {
+        if (!$metaStations) {
+            for ($i = 1; $i <= 20; $i++) {
+                $oaci = estacion_id_to_oaci($i);
+                if ($oaci) {
+                    $metaStations[$oaci] = [
+                        'oaci' => $oaci,
+                        'nombre' => '',
+                        'region' => '',
+                    ];
+                }
+            }
+        }
+        $stations = [];
+        foreach ($metaStations as $info) {
+            $stations[] = [
+                'oaci' => $info['oaci'],
+                'nombre' => $info['nombre'],
+                'region' => $info['region'],
+                'can_view' => true,
+                'can_edit' => true,
+            ];
+        }
+        echo json_encode(['ok' => true, 'stations' => $stations], JSON_UNESCAPED_UNICODE);
+        return;
+    }
+
+    $st = $pdo->prepare("SELECT UPPER(TRIM(oaci)) AS oaci, MAX(can_view) AS can_view, MAX(can_edit) AS can_edit FROM user_station_perms WHERE user_id = ? GROUP BY oaci");
+    $st->execute([(int)$user['id']]);
+    $stations = [];
+    foreach ($st->fetchAll(PDO::FETCH_ASSOC) as $row) {
+        $oaci = strtoupper(trim((string)($row['oaci'] ?? '')));
+        if ($oaci === '' || (int)($row['can_view'] ?? 0) !== 1) {
+            continue;
+        }
+        $info = $metaStations[$oaci] ?? [
+            'oaci' => $oaci,
+            'nombre' => '',
+            'region' => '',
+        ];
+        $stations[] = [
+            'oaci' => $info['oaci'],
+            'nombre' => $info['nombre'],
+            'region' => $info['region'],
+            'can_view' => true,
+            'can_edit' => ((int)($row['can_edit'] ?? 0) === 1),
+        ];
+    }
+
+    echo json_encode(['ok' => true, 'stations' => $stations], JSON_UNESCAPED_UNICODE);
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode(['ok' => false, 'error' => 'server_error'], JSON_UNESCAPED_UNICODE);
+}

--- a/api/users_create.php
+++ b/api/users_create.php
@@ -1,0 +1,180 @@
+<?php
+declare(strict_types=1);
+header('Content-Type: application/json; charset=utf-8');
+header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+header('Pragma: no-cache');
+
+$ROOT = dirname(__DIR__);
+require_once $ROOT . '/lib/session.php';
+session_boot();
+require_once $ROOT . '/lib/db.php';
+require_once $ROOT . '/lib/auth.php';
+
+$u = auth_user();
+if (!$u) {
+  http_response_code(401);
+  echo json_encode(['ok' => false, 'error' => 'unauthorized', 'msg' => 'Sesión inválida.']);
+  exit;
+}
+$creatorRole = strtolower((string)($u['role'] ?? 'viewer'));
+if ($creatorRole === 'viewer') {
+  http_response_code(403);
+  echo json_encode(['ok' => false, 'error' => 'forbidden', 'msg' => 'No tienes permisos para crear usuarios.']);
+  exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+  http_response_code(405);
+  echo json_encode(['ok' => false, 'error' => 'method_not_allowed']);
+  exit;
+}
+
+$pdo = db();
+
+$normalizeOaci = static function ($value): ?string {
+  $oaci = strtoupper(trim((string)$value));
+  if ($oaci === '') {
+    return null;
+  }
+  if (!preg_match('/^[A-Z0-9]{4}$/', $oaci)) {
+    return null;
+  }
+  return substr($oaci, 0, 4);
+};
+
+$rawView = array_keys($_POST['station_view'] ?? []);
+$rawEdit = array_keys($_POST['station_edit'] ?? []);
+$selectedView = [];
+foreach ($rawView as $val) {
+  $norm = $normalizeOaci($val);
+  if ($norm) {
+    $selectedView[$norm] = true;
+  }
+}
+$selectedEdit = [];
+foreach ($rawEdit as $val) {
+  $norm = $normalizeOaci($val);
+  if ($norm) {
+    $selectedEdit[$norm] = true;
+  }
+}
+
+$allowedView = [];
+$allowedEdit = [];
+if ($creatorRole !== 'admin') {
+  $perms = $pdo->prepare('SELECT UPPER(TRIM(oaci)) AS oaci, MAX(can_view) AS can_view, MAX(can_edit) AS can_edit FROM user_station_perms WHERE user_id = ? GROUP BY oaci');
+  $perms->execute([(int)$u['id']]);
+  foreach ($perms->fetchAll(PDO::FETCH_ASSOC) as $row) {
+    $oaci = strtoupper(trim((string)($row['oaci'] ?? '')));
+    if ($oaci === '') {
+      continue;
+    }
+    if ((int)($row['can_view'] ?? 0) === 1) {
+      $allowedView[$oaci] = true;
+    }
+    if ((int)($row['can_edit'] ?? 0) === 1) {
+      $allowedEdit[$oaci] = true;
+    }
+  }
+  if (!$allowedView) {
+    http_response_code(403);
+    echo json_encode(['ok' => false, 'error' => 'no_station_access', 'msg' => 'No tienes estaciones asignadas para crear usuarios.']);
+    exit;
+  }
+  $filteredView = [];
+  foreach (array_keys($selectedView) as $oaci) {
+    if (isset($allowedView[$oaci])) {
+      $filteredView[$oaci] = true;
+    }
+  }
+  $selectedView = $filteredView;
+  $filteredEdit = [];
+  foreach (array_keys($selectedEdit) as $oaci) {
+    if (isset($allowedEdit[$oaci])) {
+      $filteredEdit[$oaci] = true;
+    }
+  }
+  $selectedEdit = $filteredEdit;
+  if (!$selectedView) {
+    http_response_code(400);
+    echo json_encode(['ok' => false, 'error' => 'missing_station', 'msg' => 'Selecciona al menos una estación permitida.']);
+    exit;
+  }
+} else {
+  // Para administradores: garantizar que los edits estén incluidos en view
+  foreach (array_keys($selectedEdit) as $oaci) {
+    $selectedView[$oaci] = true;
+  }
+}
+
+// Asegura que las estaciones con edición también tengan permiso de vista
+foreach (array_keys($selectedEdit) as $oaci) {
+  $selectedView[$oaci] = true;
+}
+
+$email = trim((string)($_POST['email'] ?? ''));
+$nombre = trim((string)($_POST['nombre'] ?? ''));
+$role = (string)($_POST['role'] ?? 'viewer');
+$controlRaw = trim((string)($_POST['control'] ?? ''));
+$pass = (string)($_POST['pass'] ?? '');
+$isActive = !empty($_POST['is_active']) ? 1 : 0;
+
+if ($email === '' || $nombre === '' || $pass === '') {
+  http_response_code(400);
+  echo json_encode(['ok' => false, 'error' => 'missing_fields']);
+  exit;
+}
+
+if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+  http_response_code(400);
+  echo json_encode(['ok' => false, 'error' => 'invalid_email']);
+  exit;
+}
+
+$allowedRoles = ['admin', 'regional', 'estacion', 'viewer'];
+if (!in_array($role, $allowedRoles, true)) {
+  $role = 'viewer';
+}
+
+$control = $controlRaw === '' ? null : $controlRaw;
+if ($control !== null) {
+  $control = trim($control);
+  if ($control === '') {
+    $control = null;
+  }
+}
+
+$st = $pdo->prepare('SELECT id FROM app_users WHERE email = ? LIMIT 1');
+$st->execute([$email]);
+if ($st->fetch()) {
+  http_response_code(409);
+  echo json_encode(['ok' => false, 'error' => 'email_in_use', 'msg' => 'El correo ya está registrado.']);
+  exit;
+}
+
+$hash = password_hash($pass, PASSWORD_DEFAULT);
+
+try {
+  $pdo->beginTransaction();
+
+  $insUser = $pdo->prepare('INSERT INTO app_users (email, nombre, pass_hash, role, control, is_active) VALUES (?,?,?,?,?,?)');
+  $insUser->execute([$email, $nombre, $hash, $role, $control, $isActive]);
+  $newUserId = (int)$pdo->lastInsertId();
+
+  if (!empty($selectedView)) {
+    $insPerm = $pdo->prepare('INSERT INTO user_station_perms (user_id, oaci, can_view, can_edit) VALUES (?,?,?,?)');
+    foreach (array_keys($selectedView) as $oaci) {
+      $canEdit = !empty($selectedEdit[$oaci]) ? 1 : 0;
+      $insPerm->execute([$newUserId, $oaci, 1, $canEdit]);
+    }
+  }
+
+  $pdo->commit();
+  echo json_encode(['ok' => true, 'user_id' => $newUserId]);
+} catch (Throwable $e) {
+  if ($pdo->inTransaction()) {
+    $pdo->rollBack();
+  }
+  http_response_code(500);
+  echo json_encode(['ok' => false, 'error' => 'server_error', 'msg' => 'No se pudo crear el usuario.']);
+}

--- a/public/assets/date-mask.js
+++ b/public/assets/date-mask.js
@@ -1,0 +1,86 @@
+(function(){
+  function normalizeDigits(value){
+    const str = String(value || '').trim();
+    if (!str) return '';
+    const iso = /^(\d{4})-(\d{2})-(\d{2})$/.exec(str);
+    if (iso) {
+      return `${iso[3]}${iso[2]}${iso[1]}`;
+    }
+    return str.replace(/\D+/g, '');
+  }
+
+  function expandYear(twoDigits){
+    if (!twoDigits) return '';
+    if (twoDigits.length >= 4) return twoDigits.slice(0, 4);
+    if (twoDigits.length === 3) return twoDigits;
+    const n = parseInt(twoDigits, 10);
+    if (!Number.isFinite(n)) return '';
+    return (n >= 50 ? '19' : '20') + twoDigits.padStart(2, '0');
+  }
+
+  function formatDigits(digits){
+    if (!digits) return '';
+    const clean = digits.replace(/[^0-9]/g, '').slice(0, 8);
+    const day = clean.slice(0, 2);
+    const month = clean.slice(2, 4);
+    let year = clean.slice(4);
+    if (year.length === 2) {
+      year = expandYear(year);
+    } else if (year.length === 3) {
+      year = '2' + year.slice(0, 3);
+    } else if (year.length > 4) {
+      year = year.slice(0, 4);
+    }
+    const parts = [];
+    if (day) parts.push(day);
+    if (month) parts.push(month);
+    if (year) parts.push(year);
+    return parts.join('/');
+  }
+
+  function applyMaskToInput(input){
+    if (!input || input.dataset.dateMaskApplied) return;
+    input.dataset.dateMaskApplied = '1';
+    input.setAttribute('autocomplete', input.getAttribute('autocomplete') || 'off');
+
+    const handleInput = () => {
+      const normalized = normalizeDigits(input.value);
+      const formatted = formatDigits(normalized);
+      input.value = formatted;
+      if (input === document.activeElement && typeof input.setSelectionRange === 'function') {
+        const len = input.value.length;
+        input.setSelectionRange(len, len);
+      }
+    };
+
+    const handlePaste = (event) => {
+      const data = event.clipboardData || window.clipboardData;
+      if (!data) return;
+      event.preventDefault();
+      const digits = normalizeDigits(data.getData('text'));
+      input.value = formatDigits(digits);
+      handleInput();
+    };
+
+    input.addEventListener('input', handleInput);
+    input.addEventListener('change', handleInput);
+    input.addEventListener('blur', handleInput);
+    input.addEventListener('paste', handlePaste);
+
+    handleInput();
+  }
+
+  function init(scope){
+    const root = scope && scope.querySelectorAll ? scope : document;
+    const targets = root.querySelectorAll('input[data-mask="date"], input.js-date-mask, input[data-date-mask]');
+    targets.forEach(applyMaskToInput);
+  }
+
+  if (document.readyState !== 'loading') {
+    init(document);
+  } else {
+    document.addEventListener('DOMContentLoaded', () => init(document));
+  }
+
+  window.applyDateMask = init;
+})();

--- a/public/edit_persona.php
+++ b/public/edit_persona.php
@@ -220,12 +220,12 @@ function h($s){ return htmlspecialchars((string)$s, ENT_QUOTES, 'UTF-8'); }
         <input name="curp" class="form-control" value="<?=h($emp['curp'])?>">
       </div>
       <div>
-        <label class="form-label">Nacimiento (dd/mm/aaaa o yyyy-mm-dd)</label>
-        <input name="fecha_nacimiento" class="form-control" placeholder="dd/mm/aaaa" value="<?=h($emp['fecha_nacimiento'])?>">
+        <label class="form-label">Nacimiento (dd/mm/aaaa)</label>
+        <input name="fecha_nacimiento" class="form-control" placeholder="dd/mm/aaaa" value="<?=h($emp['fecha_nacimiento'])?>" data-mask="date" inputmode="numeric" maxlength="10" autocomplete="off">
       </div>
       <div>
         <label class="form-label">Ingreso/Antigüedad</label>
-        <input name="ant" class="form-control" placeholder="yyyy-mm-dd o dd/mm/aaaa" value="<?=h($emp['ant'])?>">
+        <input name="ant" class="form-control" placeholder="dd/mm/aaaa" value="<?=h($emp['ant'])?>" data-mask="date" inputmode="numeric" maxlength="10" autocomplete="off">
       </div>
       <div style="grid-column:1/-1">
         <label class="form-label">Dirección</label>
@@ -267,81 +267,91 @@ function h($s){ return htmlspecialchars((string)$s, ENT_QUOTES, 'UTF-8'); }
       </div>
 
       <!-- Licencias / exámenes -->
-      <div>
-        <label class="form-label">Tipo Licencia 1</label>
-        <select name="tipo1" class="form-select">
-          <option value="">—</option>
-          <?php foreach($LIC_OPC as $k=>$label): ?>
-            <option value="<?=h($k)?>" <?=$emp['tipo1']===$k?'selected':''?>><?=h($label)?></option>
-          <?php endforeach; ?>
-        </select>
-      </div>
-      <div>
-        <label class="form-label">No. Licencia 1</label>
-        <input name="licencia1" class="form-control" value="<?=h($emp['licencia1'])?>">
-      </div>
-      <div>
-        <label class="form-label">Vigencia 1</label>
-        <input name="vigencia1" class="form-control" value="<?=h($emp['vigencia1'])?>">
-      </div>
-
-      <div>
-        <label class="form-label">Tipo Licencia 2</label>
-        <select name="tipo2" class="form-select">
-          <option value="">—</option>
-          <?php foreach($LIC_OPC as $k=>$label): ?>
-            <option value="<?=h($k)?>" <?=$emp['tipo2']===$k?'selected':''?>><?=h($label)?></option>
-          <?php endforeach; ?>
-        </select>
-      </div>
-      <div>
-        <label class="form-label">No. Licencia 2</label>
-        <input name="licencia2" class="form-control" value="<?=h($emp['licencia2'])?>">
-      </div>
-      <div>
-        <label class="form-label">Vigencia 2</label>
-        <input name="vigencia2" class="form-control" value="<?=h($emp['vigencia2'])?>">
+      <div class="grid grid-3" style="grid-column:1/-1">
+        <div>
+          <label class="form-label">Tipo Licencia 1</label>
+          <select name="tipo1" class="form-select">
+            <option value="">—</option>
+            <?php foreach($LIC_OPC as $k=>$label): ?>
+              <option value="<?=h($k)?>" <?=$emp['tipo1']===$k?'selected':''?>><?=h($label)?></option>
+            <?php endforeach; ?>
+          </select>
+        </div>
+        <div>
+          <label class="form-label">No. Licencia 1</label>
+          <input name="licencia1" class="form-control" value="<?=h($emp['licencia1'])?>">
+        </div>
+        <div>
+          <label class="form-label">Vigencia 1</label>
+          <input name="vigencia1" class="form-control" value="<?=h($emp['vigencia1'])?>" placeholder="dd/mm/aaaa" data-mask="date" inputmode="numeric" maxlength="10" autocomplete="off">
+        </div>
       </div>
 
-      <div>
-        <label class="form-label">LCAR / DL</label>
-        <select name="examen1" class="form-select">
-          <option value="">—</option>
-          <?php foreach($LCAR_OPC as $k=>$label): ?>
-            <option value="<?=h($k)?>" <?=$emp['examen1']===$k?'selected':''?>><?=h($label)?></option>
-          <?php endforeach; ?>
-        </select>
-      </div>
-      <div>
-        <label class="form-label">Vigencia LCAR/DL</label>
-        <input name="examen_vig1" class="form-control" value="<?=h($emp['examen_vig1'])?>">
-      </div>
-
-      <div>
-        <label class="form-label">Clase Examen Médico</label>
-        <select name="examen2" class="form-select">
-          <option value="">—</option>
-          <?php foreach($CLASE_OPC as $k=>$label): ?>
-            <option value="<?=h($k)?>" <?=$emp['examen2']===$k?'selected':''?>><?=h($label)?></option>
-          <?php endforeach; ?>
-        </select>
-      </div>
-      <div>
-        <label class="form-label">Vigencia Examen Médico</label>
-        <input name="examen_vig2" class="form-control" value="<?=h($emp['examen_vig2'])?>">
+      <div class="grid grid-3" style="grid-column:1/-1">
+        <div>
+          <label class="form-label">Tipo Licencia 2</label>
+          <select name="tipo2" class="form-select">
+            <option value="">—</option>
+            <?php foreach($LIC_OPC as $k=>$label): ?>
+              <option value="<?=h($k)?>" <?=$emp['tipo2']===$k?'selected':''?>><?=h($label)?></option>
+            <?php endforeach; ?>
+          </select>
+        </div>
+        <div>
+          <label class="form-label">No. Licencia 2</label>
+          <input name="licencia2" class="form-control" value="<?=h($emp['licencia2'])?>">
+        </div>
+        <div>
+          <label class="form-label">Vigencia 2</label>
+          <input name="vigencia2" class="form-control" value="<?=h($emp['vigencia2'])?>" placeholder="dd/mm/aaaa" data-mask="date" inputmode="numeric" maxlength="10" autocomplete="off">
+        </div>
       </div>
 
-      <div>
-        <label class="form-label">RTARI</label>
-        <input name="rtari" class="form-control" value="<?=h($emp['rtari'])?>">
+      <div class="grid grid-3" style="grid-column:1/-1">
+        <div>
+          <label class="form-label">LCAR / DL</label>
+          <select name="examen1" class="form-select">
+            <option value="">—</option>
+            <?php foreach($LCAR_OPC as $k=>$label): ?>
+              <option value="<?=h($k)?>" <?=$emp['examen1']===$k?'selected':''?>><?=h($label)?></option>
+            <?php endforeach; ?>
+          </select>
+        </div>
+        <div>
+          <label class="form-label">Vigencia LCAR/DL</label>
+          <input name="examen_vig1" class="form-control" value="<?=h($emp['examen_vig1'])?>" placeholder="dd/mm/aaaa" data-mask="date" inputmode="numeric" maxlength="10" autocomplete="off">
+        </div>
+        <div>
+          <label class="form-label">RTARI</label>
+          <input name="rtari" class="form-control" value="<?=h($emp['rtari'])?>">
+        </div>
       </div>
-      <div>
-        <label class="form-label">Vigencia RTARI</label>
-        <input name="rtari_vig" class="form-control" value="<?=h($emp['rtari_vig'])?>">
+
+      <div class="grid grid-2" style="grid-column:1/-1">
+        <div>
+          <label class="form-label">Vigencia RTARI</label>
+          <input name="rtari_vig" class="form-control" value="<?=h($emp['rtari_vig'])?>" placeholder="dd/mm/aaaa" data-mask="date" inputmode="numeric" maxlength="10" autocomplete="off">
+        </div>
       </div>
-      <div style="grid-column:1/-1">
-        <label class="form-label">Expediente Médico</label>
-        <input name="exp_med" class="form-control" value="<?=h($emp['exp_med'])?>">
+
+      <div class="grid grid-3" style="grid-column:1/-1">
+        <div>
+          <label class="form-label">Clase Examen Médico</label>
+          <select name="examen2" class="form-select">
+            <option value="">—</option>
+            <?php foreach($CLASE_OPC as $k=>$label): ?>
+              <option value="<?=h($k)?>" <?=$emp['examen2']===$k?'selected':''?>><?=h($label)?></option>
+            <?php endforeach; ?>
+          </select>
+        </div>
+        <div>
+          <label class="form-label">Expediente Médico</label>
+          <input name="exp_med" class="form-control" value="<?=h($emp['exp_med'])?>">
+        </div>
+        <div>
+          <label class="form-label">Vigencia Examen Médico</label>
+          <input name="examen_vig2" class="form-control" value="<?=h($emp['examen_vig2'])?>" placeholder="dd/mm/aaaa" data-mask="date" inputmode="numeric" maxlength="10" autocomplete="off">
+        </div>
       </div>
     </div>
 

--- a/public/includes/Foot-js.php
+++ b/public/includes/Foot-js.php
@@ -13,6 +13,7 @@ $JS = [
   asset_version('/public/assets/js/jquery-3.7.1.min.js'),
   asset_version('/public/assets/bootstrap-5.3.8-dist/js/bootstrap.bundle.min.js'),
   asset_version('/public/assets/js/datatables.min.js'),
+  asset_version('/public/assets/date-mask.js'),
   asset_version('/public/assets/app.js'), // tu inicializador
   asset_version('/public/assets/js/app_no_ficha.js'),
   asset_version('/public/assets/js/app_lic_button.js'),

--- a/public/index.php
+++ b/public/index.php
@@ -10,6 +10,7 @@ if (!$u) {
   header('Location: ' . rtrim(BASE_URL, '/') . '/login.php?err=timeout');
   exit;
 }
+$role = (string)($u['role'] ?? 'viewer');
 ?>
 <!doctype html>
 <html lang="es" data-bs-theme="dark" data-theme="dark">
@@ -46,11 +47,17 @@ if (!$u) {
     </div>
 
     <!-- DERECHA: BOTONERA / MENÚ USUARIO -->
-    <div class="nav-right d-flex align-items-center justify-content-end gap-2">
-      <?php if (function_exists('is_admin') && is_admin()): ?>
-        <a class="btn btn-outline-primary btn-sm" href="../admin/usuarios.php">Admin</a>
-        <a class="btn btn-outline-primary btn-sm" href="/public/diagnose.php">Diagnóstico</a>
-      <?php endif; ?>      <a class="btn btn-outline-primary btn-sm" href="/public/prestaciones.php">Prestaciones</a>
+      <div class="nav-right d-flex align-items-center justify-content-end gap-2">
+        <?php if ($role !== 'viewer'): ?>
+          <button type="button" class="btn btn-outline-success btn-sm" data-bs-toggle="modal" data-bs-target="#userCreateModal">
+            Crear usuario
+          </button>
+        <?php endif; ?>
+        <?php if (function_exists('is_admin') && is_admin()): ?>
+          <a class="btn btn-outline-primary btn-sm" href="../admin/usuarios.php">Admin</a>
+          <a class="btn btn-outline-primary btn-sm" href="/public/diagnose.php">Diagnóstico</a>
+        <?php endif; ?>
+        <a class="btn btn-outline-primary btn-sm" href="/public/prestaciones.php">Prestaciones</a>
       <div class="dropdown">
         <button class="btn btn-outline-secondary btn-sm dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
           <?= htmlspecialchars($u['nombre'] ?? $u['email'] ?? 'Usuario') ?>
@@ -110,6 +117,68 @@ if (!$u) {
     </div>
 
 
+    <?php if ($role !== 'viewer'): ?>
+    <!-- Modal: Crear usuario -->
+    <div class="modal fade" id="userCreateModal" tabindex="-1" aria-hidden="true" data-user-role="<?= htmlspecialchars($role) ?>">
+      <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+          <div class="modal-header border-0">
+            <h5 class="modal-title">Crear usuario</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+          </div>
+          <div class="modal-body">
+            <form id="userCreateForm" class="row g-3">
+              <div class="col-12 col-sm-6">
+                <label class="form-label" for="userCreateControl">Número de control</label>
+                <input id="userCreateControl" name="control" type="number" class="form-control" min="0" step="1" inputmode="numeric" required>
+              </div>
+              <div class="col-12 col-sm-6">
+                <label class="form-label" for="userCreateEmail">Correo electrónico</label>
+                <input id="userCreateEmail" name="email" type="email" class="form-control" required>
+              </div>
+              <div class="col-12">
+                <label class="form-label" for="userCreateName">Nombre completo</label>
+                <input id="userCreateName" name="nombre" type="text" class="form-control" required>
+              </div>
+              <div class="col-12 col-sm-6">
+                <label class="form-label" for="userCreateRole">Rol</label>
+                <select id="userCreateRole" name="role" class="form-select">
+                  <option value="admin">SuperUser (acceso total)</option>
+                  <option value="regional">Regional</option>
+                  <option value="estacion">Estación</option>
+                  <option value="viewer" selected>Solo visualización</option>
+                </select>
+              </div>
+              <div class="col-12 col-sm-6">
+                <label class="form-label" for="userCreatePass">Contraseña inicial</label>
+                <input id="userCreatePass" name="pass" type="text" class="form-control" required>
+              </div>
+              <div class="col-12">
+                <label class="form-label" for="userCreateStationsList">Estaciones asignadas</label>
+                <div id="userCreateStationsWrap" class="p-3 border rounded-3" style="background:rgba(20,26,38,.65);">
+                  <div id="userCreateStationsStatus" class="small text-secondary">Cargando estaciones disponibles…</div>
+                  <div id="userCreateStationsList" class="vstack gap-2 mt-2"></div>
+                </div>
+                <div class="form-text">Selecciona las estaciones que podrá consultar este usuario.</div>
+              </div>
+              <div class="col-12">
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" id="userCreateActive" name="is_active" checked>
+                  <label class="form-check-label" for="userCreateActive">Activo</label>
+                </div>
+              </div>
+            </form>
+            <div id="userCreateMsg" class="small text-secondary mt-2"></div>
+          </div>
+          <div class="modal-footer border-0">
+            <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
+            <button type="submit" form="userCreateForm" class="btn btn-primary" id="userCreateSubmit">Guardar</button>
+          </div>
+      </div>
+    </div>
+    </div>
+    <?php endif; ?>
+
     <!-- Modal: Documentos -->
     <div class="modal fade" id="docModal" tabindex="-1" aria-hidden="true">
       <div class="modal-dialog modal-lg modal-dialog-centered">
@@ -167,5 +236,6 @@ if (!$u) {
 
 <?php require __DIR__ . '/includes/Foot-js.php'; ?>
 <!-- Toda la lógica de la tabla/documents vive en /public/assets/app.js -->
+</body>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expose the user creation modal to all non-visualización roles, add station permission selection backed by a new API, and harden the creation endpoint to enforce station constraints
- add a reusable date-mask script, apply auto-formatting to prestaciones modals, and reorganize the edit persona form so license and exam blocks group fields consistently
- update shared scripts to initialize the new date mask utilities and improve station permission handling in the dashboard modal

## Testing
- php -l public/index.php
- php -l api/users_create.php
- php -l api/user_station_options.php
- php -l public/edit_persona.php
- php -l public/prestaciones.php

------
https://chatgpt.com/codex/tasks/task_e_68d3348389b4832b9c1ac09dec5a577d