### PR TITLE
Replace user creation modal with personal record form

### DIFF
--- a/api/empleados_create.php
+++ b/api/empleados_create.php
@@ -1,0 +1,189 @@
+<?php
+declare(strict_types=1);
+header('Content-Type: application/json; charset=utf-8');
+header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+header('Pragma: no-cache');
+
+$ROOT = dirname(__DIR__);
+require_once $ROOT . '/lib/session.php';
+session_boot();
+require_once $ROOT . '/lib/db.php';
+require_once $ROOT . '/lib/auth.php';
+require_once $ROOT . '/lib/perm.php';
+
+function json_exit(array $payload, int $status = 200): void {
+    http_response_code($status);
+    echo json_encode($payload, JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+$u = auth_user();
+if (!$u) {
+    json_exit(['ok' => false, 'error' => 'No autorizado'], 401);
+}
+
+$role = (string)($u['role'] ?? $u['rol'] ?? '');
+if ($role === 'viewer') {
+    json_exit(['ok' => false, 'error' => 'Sin permiso para crear registros'], 403);
+}
+
+$pdo = db();
+
+$ESPECS = ['MANDOS','ATCO','OSIV','ADMIN','IDS'];
+$LIC_TYPES = ['CTA III','OOA','MET I','TEC MTTO','CAM'];
+$LCAR_TYPES = ['A','B','C','DL'];
+$CLASE_TYPES = ['GPO-3','GPO-4','CLASE-3'];
+
+$rawControl = trim((string)($_POST['control'] ?? ''));
+$control = preg_replace('/\D+/', '', $rawControl);
+if ($control === '') {
+    json_exit(['ok' => false, 'error' => 'El No. de control es obligatorio.'], 400);
+}
+
+$check = $pdo->prepare('SELECT 1 FROM empleados WHERE control = ? LIMIT 1');
+$check->execute([$control]);
+if ($check->fetchColumn()) {
+    json_exit(['ok' => false, 'error' => 'Ya existe un registro con ese número de control.'], 409);
+}
+
+$estacionId = (int)($_POST['estacion'] ?? 0);
+if ($estacionId <= 0) {
+    json_exit(['ok' => false, 'error' => 'Selecciona una estación válida.'], 400);
+}
+
+$stationStmt = $pdo->prepare('SELECT UPPER(oaci) AS oaci FROM estaciones WHERE id_estacion = ? LIMIT 1');
+$stationStmt->execute([$estacionId]);
+$oaci = trim((string)$stationStmt->fetchColumn());
+if ($oaci === '') {
+    json_exit(['ok' => false, 'error' => 'La estación seleccionada no existe.'], 400);
+}
+
+$allowed = cr_user_allowed_oaci($pdo, $u);
+if ($allowed !== ['*'] && !in_array($oaci, $allowed, true)) {
+    json_exit(['ok' => false, 'error' => 'No tienes permisos para registrar personal en esa estación.'], 403);
+}
+
+$normUpper = static function (mixed $value): ?string {
+    $value = trim((string)($value ?? ''));
+    if ($value === '') {
+        return null;
+    }
+    return mb_strtoupper($value, 'UTF-8');
+};
+
+$normName = static function (mixed $value): ?string {
+    $value = trim((string)($value ?? ''));
+    if ($value === '') {
+        return null;
+    }
+    $lower = mb_strtolower($value, 'UTF-8');
+    return mb_convert_case($lower, MB_CASE_TITLE, 'UTF-8');
+};
+
+$normDate = static function (mixed $value): ?string {
+    $value = trim((string)($value ?? ''));
+    if ($value === '') {
+        return null;
+    }
+    return $value;
+};
+
+$normPlain = static function (mixed $value): ?string {
+    $value = trim((string)($value ?? ''));
+    return $value === '' ? null : $value;
+};
+
+$espec = strtoupper(trim((string)($_POST['espec'] ?? '')));
+if ($espec !== '' && !in_array($espec, $ESPECS, true)) {
+    json_exit(['ok' => false, 'error' => 'Área no válida.'], 400);
+}
+
+$tipo1 = strtoupper(trim((string)($_POST['tipo1'] ?? '')));
+if ($tipo1 !== '' && !in_array($tipo1, $LIC_TYPES, true)) {
+    json_exit(['ok' => false, 'error' => 'Tipo de licencia 1 no válido.'], 400);
+}
+
+$tipo2 = strtoupper(trim((string)($_POST['tipo2'] ?? '')));
+if ($tipo2 !== '' && !in_array($tipo2, $LIC_TYPES, true)) {
+    json_exit(['ok' => false, 'error' => 'Tipo de licencia 2 no válido.'], 400);
+}
+
+$examen1 = strtoupper(trim((string)($_POST['examen1'] ?? '')));
+if ($examen1 !== '' && !in_array($examen1, $LCAR_TYPES, true)) {
+    json_exit(['ok' => false, 'error' => 'Tipo LCAR/DL no válido.'], 400);
+}
+
+$examen2 = strtoupper(trim((string)($_POST['examen2'] ?? '')));
+if ($examen2 !== '' && !in_array($examen2, $CLASE_TYPES, true)) {
+    json_exit(['ok' => false, 'error' => 'Clase de examen médico no válida.'], 400);
+}
+
+$nombres = $normName($_POST['nombres'] ?? '');
+if ($nombres === null) {
+    json_exit(['ok' => false, 'error' => 'El nombre es obligatorio.'], 400);
+}
+
+$email = $normPlain($_POST['email'] ?? '');
+if ($email !== null) {
+    $email = mb_strtolower($email, 'UTF-8');
+}
+
+$data = [
+    'control'          => $control,
+    'siglas'           => $normUpper($_POST['siglas'] ?? ''),
+    'nombres'          => $nombres,
+    'email'            => $email,
+    'rfc'              => $normUpper($_POST['rfc'] ?? ''),
+    'curp'             => $normUpper($_POST['curp'] ?? ''),
+    'fecha_nacimiento' => $normDate($_POST['fecha_nacimiento'] ?? ''),
+    'ant'              => $normDate($_POST['ant'] ?? ''),
+    'direccion'        => $normUpper($_POST['direccion'] ?? ''),
+    'plaza'            => $normUpper($_POST['plaza'] ?? ''),
+    'espec'            => $espec === '' ? null : $espec,
+    'estacion'         => $estacionId,
+    'nivel'            => $normPlain($_POST['nivel'] ?? ''),
+    'nss'              => $normPlain($_POST['nss'] ?? ''),
+    'puesto'           => $normUpper($_POST['puesto'] ?? ''),
+    'tipo1'            => $tipo1 === '' ? null : $tipo1,
+    'licencia1'        => $normPlain($_POST['licencia1'] ?? ''),
+    'vigencia1'        => $normDate($_POST['vigencia1'] ?? ''),
+    'tipo2'            => $tipo2 === '' ? null : $tipo2,
+    'licencia2'        => $normPlain($_POST['licencia2'] ?? ''),
+    'vigencia2'        => $normDate($_POST['vigencia2'] ?? ''),
+    'examen1'          => $examen1 === '' ? null : $examen1,
+    'examen_vig1'      => $normDate($_POST['examen_vig1'] ?? ''),
+    'examen2'          => $examen2 === '' ? null : $examen2,
+    'examen_vig2'      => $normDate($_POST['examen_vig2'] ?? ''),
+    'rtari'            => $normUpper($_POST['rtari'] ?? ''),
+    'rtari_vig'        => $normDate($_POST['rtari_vig'] ?? ''),
+    'exp_med'          => $normPlain($_POST['exp_med'] ?? ''),
+];
+
+$sql = 'INSERT INTO empleados (
+            control, siglas, nombres, email, rfc, curp, fecha_nacimiento, ant, direccion,
+            plaza, espec, estacion, nivel, nss, puesto,
+            tipo1, licencia1, vigencia1,
+            tipo2, licencia2, vigencia2,
+            examen1, examen_vig1, examen2, examen_vig2,
+            rtari, rtari_vig, exp_med
+        ) VALUES (
+            :control, :siglas, :nombres, :email, :rfc, :curp, :fecha_nacimiento, :ant, :direccion,
+            :plaza, :espec, :estacion, :nivel, :nss, :puesto,
+            :tipo1, :licencia1, :vigencia1,
+            :tipo2, :licencia2, :vigencia2,
+            :examen1, :examen_vig1, :examen2, :examen_vig2,
+            :rtari, :rtari_vig, :exp_med
+        )';
+
+try {
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute($data);
+} catch (Throwable $e) {
+    json_exit([
+        'ok' => false,
+        'error' => 'No se pudo crear el registro.',
+        'detail' => $e->getMessage(),
+    ], 500);
+}
+
+json_exit(['ok' => true, 'control' => $control]);

--- a/public/assets/app.js
+++ b/public/assets/app.js
@@ -822,173 +822,49 @@ const rtari = renderRTARI(row.rtari, row.rtari_vig);
     return dt;
   }
 
-  function initUserCreateModal() {
-    const modalEl = document.getElementById('userCreateModal');
+  function initRecordCreateModal() {
+    const modalEl = document.getElementById('recordCreateModal');
     if (!modalEl) return;
-    const form = modalEl.querySelector('#userCreateForm');
-    const msg = modalEl.querySelector('#userCreateMsg');
-    const submitBtn = modalEl.querySelector('#userCreateSubmit');
-    const activeInput = form ? form.querySelector('#userCreateActive') : null;
-    const stationList = form ? form.querySelector('#userCreateStationsList') : null;
-    const stationStatus = form ? form.querySelector('#userCreateStationsStatus') : null;
-    const creatorRole = (modalEl.getAttribute('data-user-role') || 'viewer').toLowerCase();
-    let stationsPromise = null;
+    const form = modalEl.querySelector('#recordCreateForm');
+    const submitBtn = modalEl.querySelector('#recordCreateSubmit');
+    const msg = modalEl.querySelector('#recordCreateMsg');
+    const hasStations = modalEl.getAttribute('data-has-stations') === '1';
+    const controlInput = form ? form.querySelector('#newControl') : null;
 
-    const setStationStatus = (text, tone = 'secondary') => {
-      if (!stationStatus) return;
-      stationStatus.textContent = text;
-      stationStatus.className = `small text-${tone}`;
-    };
-
-    const renderStations = (stations) => {
-      if (!stationList) return;
-      stationList.innerHTML = '';
-      const rows = Array.isArray(stations) ? [...stations] : [];
-      if (!rows.length) {
-        setStationStatus('No tienes estaciones asignadas. Solicita al administrador mapearlas antes de crear usuarios.', 'warning');
-        if (submitBtn && creatorRole !== 'admin') submitBtn.disabled = true;
-        return;
-      }
-      rows.sort((a, b) => String(a.oaci || '').localeCompare(String(b.oaci || '')));
-      rows.forEach((station) => {
-        const oaci = String(station.oaci || '').trim().toUpperCase();
-        if (!oaci) return;
-        const row = document.createElement('div');
-        row.className = 'd-flex align-items-center justify-content-between flex-wrap gap-2 border rounded-3 px-3 py-2';
-        row.setAttribute('data-station', oaci);
-        const title = document.createElement('div');
-        title.className = 'd-flex align-items-center gap-2';
-        const strong = document.createElement('strong');
-        strong.textContent = oaci;
-        title.appendChild(strong);
-        const metaParts = [];
-        if (station.nombre) metaParts.push(String(station.nombre));
-        if (station.region) metaParts.push(String(station.region));
-        if (metaParts.length) {
-          const meta = document.createElement('span');
-          meta.className = 'small text-secondary';
-          meta.textContent = metaParts.join(' · ');
-          title.appendChild(meta);
-        }
-        const toggles = document.createElement('div');
-        toggles.className = 'd-flex align-items-center gap-3 flex-wrap';
-
-        const createToggle = (kind, label, enabled) => {
-          const wrap = document.createElement('div');
-          wrap.className = 'form-check form-check-inline mb-0';
-          const id = `uc-${oaci}-${kind}`;
-          const input = document.createElement('input');
-          input.type = 'checkbox';
-          input.className = 'form-check-input';
-          input.name = `station_${kind}[${oaci}]`;
-          input.id = id;
-          input.value = '1';
-          input.dataset.role = kind === 'view' ? 'view-toggle' : 'edit-toggle';
-          if (!enabled) {
-            input.disabled = true;
-            input.dataset.disabled = '1';
-          }
-          const lab = document.createElement('label');
-          lab.className = 'form-check-label small';
-          lab.setAttribute('for', id);
-          lab.textContent = label;
-          wrap.appendChild(input);
-          wrap.appendChild(lab);
-          return wrap;
-        };
-
-        toggles.appendChild(createToggle('view', 'Ver', station.can_view !== false));
-        toggles.appendChild(createToggle('edit', 'Editar', station.can_edit === true));
-
-        row.appendChild(title);
-        row.appendChild(toggles);
-        stationList.appendChild(row);
-      });
-      setStationStatus('Marca Ver y/o Editar para las estaciones permitidas.', 'secondary');
-      if (submitBtn) submitBtn.disabled = false;
-    };
-
-    const ensureStations = async () => {
-      if (!stationList || stationsPromise) return stationsPromise;
-      setStationStatus('Cargando estaciones disponibles…', 'secondary');
-      stationsPromise = fetchJSON(`${API_BASE}user_station_options.php`)
-        .then((data) => {
-          renderStations(data && Array.isArray(data.stations) ? data.stations : []);
-          return data;
-        })
-        .catch((err) => {
-          setStationStatus(err && err.message ? err.message : 'No se pudieron cargar las estaciones disponibles.', 'danger');
-          if (submitBtn) submitBtn.disabled = true;
-          stationsPromise = null;
-          throw err;
-        });
-      return stationsPromise;
-    };
-
-    const resetForm = () => {
+    const reset = () => {
       if (form) {
         form.reset();
-        if (activeInput) activeInput.checked = true;
-        if (stationList) {
-          stationList.querySelectorAll('input[type="checkbox"]').forEach((input) => {
-            if (!input.disabled) input.checked = false;
-          });
-        }
       }
       if (msg) {
         msg.textContent = '';
         msg.className = 'small text-secondary mt-2';
       }
-      if (submitBtn) submitBtn.disabled = false;
-      if (stationStatus) {
-        if (stationsPromise) {
-          const hasRows = stationList && stationList.querySelector('[data-station]');
-          setStationStatus(hasRows ? 'Marca Ver y/o Editar para las estaciones permitidas.' : 'No tienes estaciones asignadas. Solicita al administrador mapearlas antes de crear usuarios.', hasRows ? 'secondary' : 'warning');
-        } else {
-          setStationStatus('Cargando estaciones disponibles…', 'secondary');
-        }
-      }
+      if (submitBtn) submitBtn.disabled = hasStations ? false : true;
     };
 
-    modalEl.addEventListener('hidden.bs.modal', resetForm);
-    modalEl.addEventListener('show.bs.modal', () => {
-      if (!stationsPromise) {
-        ensureStations().catch(() => {});
-      } else if (stationStatus) {
-        const hasRows = stationList && stationList.querySelector('[data-station]');
-        setStationStatus(hasRows ? 'Marca Ver y/o Editar para las estaciones permitidas.' : 'No tienes estaciones asignadas. Solicita al administrador mapearlas antes de crear usuarios.', hasRows ? 'secondary' : 'warning');
+    modalEl.addEventListener('hidden.bs.modal', reset);
+    modalEl.addEventListener('shown.bs.modal', () => {
+      if (controlInput) {
+        controlInput.focus();
+        if (typeof controlInput.select === 'function') {
+          controlInput.select();
+        }
       }
     });
-
-    if (stationList) {
-      stationList.addEventListener('change', (event) => {
-        const target = event.target;
-        if (!target || !target.matches('[data-role="edit-toggle"]')) return;
-        if (!target.checked) return;
-        const row = target.closest('[data-station]');
-        const viewToggle = row ? row.querySelector('[data-role="view-toggle"]') : null;
-        if (viewToggle && !viewToggle.checked && !viewToggle.disabled) {
-          viewToggle.checked = true;
-        }
-      });
-    }
 
     if (!form) return;
     form.addEventListener('submit', async (event) => {
       event.preventDefault();
       if (!submitBtn) return;
-      if (!stationsPromise) {
-        try { await ensureStations(); } catch (err) { return; }
-      }
-      if (creatorRole !== 'admin') {
-        const hasStation = form.querySelector('input[name^="station_view"][type="checkbox"]:checked');
-        if (!hasStation) {
-          if (msg) {
-            msg.textContent = 'Selecciona al menos una estación para el nuevo usuario.';
-            msg.className = 'small text-danger mt-2';
-          }
-          return;
+      if (!hasStations) {
+        if (msg) {
+          msg.textContent = 'No tienes estaciones mapeadas para crear registros nuevos.';
+          msg.className = 'small text-danger mt-2';
         }
+        return;
+      }
+      if (typeof form.reportValidity === 'function' && !form.reportValidity()) {
+        return;
       }
       submitBtn.disabled = true;
       if (msg) {
@@ -997,10 +873,14 @@ const rtari = renderRTARI(row.rtari, row.rtari_vig);
       }
       const fd = new FormData(form);
       try {
-        await fetchJSON(`${API_BASE}users_create.php`, { method: 'POST', body: fd });
+        await fetchJSON(`${API_BASE}empleados_create.php`, { method: 'POST', body: fd });
         if (msg) {
-          msg.textContent = 'Usuario creado correctamente.';
+          msg.textContent = 'Registro creado correctamente.';
           msg.className = 'small text-success mt-2';
+        }
+        const table = $('#tabla').DataTable();
+        if (table) {
+          table.ajax.reload(null, false);
         }
         setTimeout(() => {
           const modal = bootstrap.Modal.getInstance(modalEl);
@@ -1008,7 +888,7 @@ const rtari = renderRTARI(row.rtari, row.rtari_vig);
         }, 600);
       } catch (err) {
         if (msg) {
-          msg.textContent = err && err.message ? err.message : 'No se pudo crear el usuario.';
+          msg.textContent = err && err.message ? err.message : 'No se pudo crear el registro.';
           msg.className = 'small text-danger mt-2';
         }
       } finally {
@@ -1021,7 +901,7 @@ const rtari = renderRTARI(row.rtari, row.rtari_vig);
   // Arranque
   // ================================
   onReady(() => {
-    initUserCreateModal();
+    initRecordCreateModal();
     buildTable('lic'); // vista default
   });
 })();

--- a/public/index.php
+++ b/public/index.php
@@ -11,6 +11,35 @@ if (!$u) {
   exit;
 }
 $role = (string)($u['role'] ?? 'viewer');
+$pdo  = db();
+
+$ESPECS = ['MANDOS'=>'MANDOS','ATCO'=>'ATCO','OSIV'=>'OSIV','ADMIN'=>'APOYO ADMON','IDS'=>'IDS'];
+$LIC_OPC = ['CTA III'=>'CTA III','OOA'=>'OOA','MET I'=>'MET I','TEC MTTO'=>'TEC MTTO','CAM'=>'Conducción GAP (CAM)'];
+$LCAR_OPC = ['A'=>'Tipo A','B'=>'Tipo B','C'=>'Tipo C','DL'=>'DL'];
+$CLASE_OPC = ['GPO-3'=>'GPO-3','GPO-4'=>'GPO-4','CLASE-3'=>'CLASE-3'];
+
+$stationOptions = [];
+try {
+  $st = $pdo->query('SELECT id_estacion, oaci FROM estaciones ORDER BY oaci');
+  while ($row = $st->fetch(PDO::FETCH_ASSOC)) {
+    $id = (int)($row['id_estacion'] ?? 0);
+    $oaci = strtoupper(trim((string)($row['oaci'] ?? '')));
+    if ($id > 0 && $oaci !== '') {
+      $stationOptions[] = ['id' => $id, 'oaci' => $oaci];
+    }
+  }
+} catch (Throwable $e) {
+  $stationOptions = [];
+}
+
+if (!is_admin()) {
+  $matrix = function_exists('user_station_matrix') ? user_station_matrix($pdo, (int)($u['id'] ?? 0)) : [];
+  $stationOptions = array_values(array_filter($stationOptions, static function (array $opt) use ($matrix): bool {
+    $oaci = $opt['oaci'] ?? '';
+    return $oaci !== '' && !empty($matrix[$oaci]);
+  }));
+}
+$hasStationAccess = is_admin() || count($stationOptions) > 0;
 ?>
 <!doctype html>
 <html lang="es" data-bs-theme="dark" data-theme="dark">
@@ -47,10 +76,10 @@ $role = (string)($u['role'] ?? 'viewer');
     </div>
 
     <!-- DERECHA: BOTONERA / MENÚ USUARIO -->
-      <div class="nav-right d-flex align-items-center justify-content-end gap-2">
+      <div class="nav-right d-flex flex-wrap align-items-center justify-content-end gap-2 text-end">
         <?php if ($role !== 'viewer'): ?>
-          <button type="button" class="btn btn-outline-success btn-sm" data-bs-toggle="modal" data-bs-target="#userCreateModal">
-            Crear usuario
+          <button type="button" class="btn btn-outline-success btn-sm" data-bs-toggle="modal" data-bs-target="#recordCreateModal">
+            Agregar registro
           </button>
         <?php endif; ?>
         <?php if (function_exists('is_admin') && is_admin()): ?>
@@ -118,64 +147,195 @@ $role = (string)($u['role'] ?? 'viewer');
 
 
     <?php if ($role !== 'viewer'): ?>
-    <!-- Modal: Crear usuario -->
-    <div class="modal fade" id="userCreateModal" tabindex="-1" aria-hidden="true" data-user-role="<?= htmlspecialchars($role) ?>">
-      <div class="modal-dialog modal-dialog-centered">
+    <!-- Modal: Agregar registro -->
+    <div class="modal fade" id="recordCreateModal" tabindex="-1" aria-hidden="true" data-has-stations="<?= $hasStationAccess ? '1' : '0' ?>">
+      <div class="modal-dialog modal-xl modal-dialog-centered modal-dialog-scrollable">
         <div class="modal-content">
           <div class="modal-header border-0">
-            <h5 class="modal-title">Crear usuario</h5>
+            <h5 class="modal-title">Agregar nuevo registro</h5>
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
           </div>
           <div class="modal-body">
-            <form id="userCreateForm" class="row g-3">
-              <div class="col-12 col-sm-6">
-                <label class="form-label" for="userCreateControl">Número de control</label>
-                <input id="userCreateControl" name="control" type="number" class="form-control" min="0" step="1" inputmode="numeric" required>
-              </div>
-              <div class="col-12 col-sm-6">
-                <label class="form-label" for="userCreateEmail">Correo electrónico</label>
-                <input id="userCreateEmail" name="email" type="email" class="form-control" required>
-              </div>
-              <div class="col-12">
-                <label class="form-label" for="userCreateName">Nombre completo</label>
-                <input id="userCreateName" name="nombre" type="text" class="form-control" required>
-              </div>
-              <div class="col-12 col-sm-6">
-                <label class="form-label" for="userCreateRole">Rol</label>
-                <select id="userCreateRole" name="role" class="form-select">
-                  <option value="admin">SuperUser (acceso total)</option>
-                  <option value="regional">Regional</option>
-                  <option value="estacion">Estación</option>
-                  <option value="viewer" selected>Solo visualización</option>
-                </select>
-              </div>
-              <div class="col-12 col-sm-6">
-                <label class="form-label" for="userCreatePass">Contraseña inicial</label>
-                <input id="userCreatePass" name="pass" type="text" class="form-control" required>
-              </div>
-              <div class="col-12">
-                <label class="form-label" for="userCreateStationsList">Estaciones asignadas</label>
-                <div id="userCreateStationsWrap" class="p-3 border rounded-3" style="background:rgba(20,26,38,.65);">
-                  <div id="userCreateStationsStatus" class="small text-secondary">Cargando estaciones disponibles…</div>
-                  <div id="userCreateStationsList" class="vstack gap-2 mt-2"></div>
+            <?php if (!$hasStationAccess): ?>
+              <div class="alert alert-warning">No cuentas con estaciones asignadas. Solicita al administrador mapearte al menos una para poder crear registros nuevos.</div>
+            <?php endif; ?>
+            <form id="recordCreateForm">
+              <fieldset class="row g-3" <?= $hasStationAccess ? '' : 'disabled' ?>>
+                <div class="col-12 col-sm-6 col-lg-3">
+                  <label class="form-label" for="newControl">No. de control</label>
+                  <input id="newControl" name="control" type="text" class="form-control" inputmode="numeric" pattern="\d+" required>
                 </div>
-                <div class="form-text">Selecciona las estaciones que podrá consultar este usuario.</div>
-              </div>
-              <div class="col-12">
-                <div class="form-check">
-                  <input class="form-check-input" type="checkbox" id="userCreateActive" name="is_active" checked>
-                  <label class="form-check-label" for="userCreateActive">Activo</label>
+                <div class="col-12 col-sm-6 col-lg-3">
+                  <label class="form-label" for="newSiglas">Siglas</label>
+                  <input id="newSiglas" name="siglas" type="text" class="form-control" maxlength="3" autocomplete="off">
                 </div>
-              </div>
+                <div class="col-12 col-lg-6">
+                  <label class="form-label" for="newNombre">Nombre completo</label>
+                  <input id="newNombre" name="nombres" type="text" class="form-control" required>
+                </div>
+                <div class="col-12 col-lg-6">
+                  <label class="form-label" for="newEmail">Correo electrónico</label>
+                  <input id="newEmail" name="email" type="email" class="form-control" autocomplete="off">
+                </div>
+                <div class="col-12 col-sm-6 col-lg-3">
+                  <label class="form-label" for="newRFC">RFC</label>
+                  <input id="newRFC" name="rfc" type="text" class="form-control" autocomplete="off">
+                </div>
+                <div class="col-12 col-sm-6 col-lg-3">
+                  <label class="form-label" for="newCURP">CURP</label>
+                  <input id="newCURP" name="curp" type="text" class="form-control" autocomplete="off">
+                </div>
+                <div class="col-12 col-sm-6 col-lg-3">
+                  <label class="form-label" for="newNacimiento">Nacimiento</label>
+                  <input id="newNacimiento" name="fecha_nacimiento" type="text" class="form-control" placeholder="dd/mm/aaaa" data-mask="date" inputmode="numeric" maxlength="10" autocomplete="off">
+                </div>
+                <div class="col-12 col-sm-6 col-lg-3">
+                  <label class="form-label" for="newAnt">Antigüedad</label>
+                  <input id="newAnt" name="ant" type="text" class="form-control" placeholder="dd/mm/aaaa" data-mask="date" inputmode="numeric" maxlength="10" autocomplete="off">
+                </div>
+                <div class="col-12">
+                  <label class="form-label" for="newDireccion">Dirección</label>
+                  <textarea id="newDireccion" name="direccion" class="form-control" rows="2"></textarea>
+                </div>
+                <div class="col-12 col-sm-6 col-lg-3">
+                  <label class="form-label" for="newPlaza">Código Plaza</label>
+                  <input id="newPlaza" name="plaza" type="text" class="form-control" autocomplete="off">
+                </div>
+                <div class="col-12 col-sm-6 col-lg-3">
+                  <label class="form-label" for="newEspec">Área</label>
+                  <select id="newEspec" name="espec" class="form-select">
+                    <option value="">—</option>
+                    <?php foreach ($ESPECS as $k => $label): ?>
+                      <option value="<?= htmlspecialchars($k) ?>"><?= htmlspecialchars($label) ?></option>
+                    <?php endforeach; ?>
+                  </select>
+                </div>
+                <div class="col-12 col-sm-6 col-lg-3">
+                  <label class="form-label" for="newEstacion">Estación</label>
+                  <select id="newEstacion" name="estacion" class="form-select" required>
+                    <option value="">—</option>
+                    <?php foreach ($stationOptions as $opt): ?>
+                      <option value="<?= (int)$opt['id'] ?>"><?= htmlspecialchars($opt['oaci']) ?></option>
+                    <?php endforeach; ?>
+                  </select>
+                  <?php if (!is_admin()): ?>
+                    <div class="form-text">Solo podrás elegir entre tus estaciones asignadas.</div>
+                  <?php endif; ?>
+                </div>
+                <div class="col-12 col-sm-6 col-lg-3">
+                  <label class="form-label" for="newNivel">Nivel</label>
+                  <input id="newNivel" name="nivel" type="text" class="form-control" autocomplete="off">
+                </div>
+                <div class="col-12 col-sm-6 col-lg-3">
+                  <label class="form-label" for="newNSS">NSS</label>
+                  <input id="newNSS" name="nss" type="text" class="form-control" autocomplete="off">
+                </div>
+                <div class="col-12">
+                  <label class="form-label" for="newPuesto">Nombramiento / Puesto</label>
+                  <input id="newPuesto" name="puesto" type="text" class="form-control" autocomplete="off">
+                </div>
+                <div class="col-12">
+                  <div class="row g-3">
+                    <div class="col-12 col-md-4">
+                      <label class="form-label" for="newTipo1">Tipo licencia 1</label>
+                      <select id="newTipo1" name="tipo1" class="form-select">
+                        <option value="">—</option>
+                        <?php foreach ($LIC_OPC as $k => $label): ?>
+                          <option value="<?= htmlspecialchars($k) ?>"><?= htmlspecialchars($label) ?></option>
+                        <?php endforeach; ?>
+                      </select>
+                    </div>
+                    <div class="col-12 col-md-4">
+                      <label class="form-label" for="newLic1">No. licencia 1</label>
+                      <input id="newLic1" name="licencia1" type="text" class="form-control" autocomplete="off">
+                    </div>
+                    <div class="col-12 col-md-4">
+                      <label class="form-label" for="newVig1">Vigencia 1</label>
+                      <input id="newVig1" name="vigencia1" type="text" class="form-control" placeholder="dd/mm/aaaa" data-mask="date" inputmode="numeric" maxlength="10" autocomplete="off">
+                    </div>
+                  </div>
+                </div>
+                <div class="col-12">
+                  <div class="row g-3">
+                    <div class="col-12 col-md-4">
+                      <label class="form-label" for="newTipo2">Tipo licencia 2</label>
+                      <select id="newTipo2" name="tipo2" class="form-select">
+                        <option value="">—</option>
+                        <?php foreach ($LIC_OPC as $k => $label): ?>
+                          <option value="<?= htmlspecialchars($k) ?>"><?= htmlspecialchars($label) ?></option>
+                        <?php endforeach; ?>
+                      </select>
+                    </div>
+                    <div class="col-12 col-md-4">
+                      <label class="form-label" for="newLic2">No. licencia 2</label>
+                      <input id="newLic2" name="licencia2" type="text" class="form-control" autocomplete="off">
+                    </div>
+                    <div class="col-12 col-md-4">
+                      <label class="form-label" for="newVig2">Vigencia 2</label>
+                      <input id="newVig2" name="vigencia2" type="text" class="form-control" placeholder="dd/mm/aaaa" data-mask="date" inputmode="numeric" maxlength="10" autocomplete="off">
+                    </div>
+                  </div>
+                </div>
+                <div class="col-12">
+                  <div class="row g-3">
+                    <div class="col-12 col-md-4">
+                      <label class="form-label" for="newExamen1">LCAR / DL</label>
+                      <select id="newExamen1" name="examen1" class="form-select">
+                        <option value="">—</option>
+                        <?php foreach ($LCAR_OPC as $k => $label): ?>
+                          <option value="<?= htmlspecialchars($k) ?>"><?= htmlspecialchars($label) ?></option>
+                        <?php endforeach; ?>
+                      </select>
+                    </div>
+                    <div class="col-12 col-md-4">
+                      <label class="form-label" for="newExamenVig1">Vigencia LCAR/DL</label>
+                      <input id="newExamenVig1" name="examen_vig1" type="text" class="form-control" placeholder="dd/mm/aaaa" data-mask="date" inputmode="numeric" maxlength="10" autocomplete="off">
+                    </div>
+                    <div class="col-12 col-md-4">
+                      <label class="form-label" for="newRTARI">RTARI</label>
+                      <input id="newRTARI" name="rtari" type="text" class="form-control" autocomplete="off">
+                    </div>
+                  </div>
+                </div>
+                <div class="col-12">
+                  <div class="row g-3">
+                    <div class="col-12 col-md-4">
+                      <label class="form-label" for="newRTARIVig">Vigencia RTARI</label>
+                      <input id="newRTARIVig" name="rtari_vig" type="text" class="form-control" placeholder="dd/mm/aaaa" data-mask="date" inputmode="numeric" maxlength="10" autocomplete="off">
+                    </div>
+                  </div>
+                </div>
+                <div class="col-12">
+                  <div class="row g-3">
+                    <div class="col-12 col-md-4">
+                      <label class="form-label" for="newExamen2">Clase examen médico</label>
+                      <select id="newExamen2" name="examen2" class="form-select">
+                        <option value="">—</option>
+                        <?php foreach ($CLASE_OPC as $k => $label): ?>
+                          <option value="<?= htmlspecialchars($k) ?>"><?= htmlspecialchars($label) ?></option>
+                        <?php endforeach; ?>
+                      </select>
+                    </div>
+                    <div class="col-12 col-md-4">
+                      <label class="form-label" for="newExpediente">Expediente médico</label>
+                      <input id="newExpediente" name="exp_med" type="text" class="form-control" autocomplete="off">
+                    </div>
+                    <div class="col-12 col-md-4">
+                      <label class="form-label" for="newExamenVig2">Vigencia examen médico</label>
+                      <input id="newExamenVig2" name="examen_vig2" type="text" class="form-control" placeholder="dd/mm/aaaa" data-mask="date" inputmode="numeric" maxlength="10" autocomplete="off">
+                    </div>
+                  </div>
+                </div>
+              </fieldset>
             </form>
-            <div id="userCreateMsg" class="small text-secondary mt-2"></div>
+            <div id="recordCreateMsg" class="small text-secondary mt-2"></div>
           </div>
           <div class="modal-footer border-0">
             <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
-            <button type="submit" form="userCreateForm" class="btn btn-primary" id="userCreateSubmit">Guardar</button>
+            <button type="submit" form="recordCreateForm" class="btn btn-primary" id="recordCreateSubmit" <?= $hasStationAccess ? '' : 'disabled' ?>>Guardar</button>
           </div>
+        </div>
       </div>
-    </div>
     </div>
     <?php endif; ?>
 


### PR DESCRIPTION
## Summary
- replace the dashboard’s user-creation button with an "Agregar registro" workflow that surfaces the full personal record form and filters station options to the user’s mapped OACI codes
- add an empleados_create API that sanitizes inputs, enforces station permissions, and inserts the new personal record into the empleados table
- wire the new modal through app.js so submissions hit the new endpoint, report status inline, and refresh the DataTable results

## Testing
- php -l public/index.php
- php -l api/empleados_create.php

------
https://chatgpt.com/codex/tasks/task_e_68d3348389b4832b9c1ac09dec5a577d