### PR TITLE
Resolve merge conflicts in scan tools

### DIFF
--- a/tools/scan_mixed_params.php
+++ b/tools/scan_mixed_params.php
@@ -1,15 +1,7 @@
-<<<<<<< HEAD
-<<<<<<< HEAD
+#!/usr/bin/env php
 <?php
 declare(strict_types=1);
-=======
-#!/usr/bin/env php
-<?php
->>>>>>> a1fc3d3 (Handle PHP builds without STDOUT constant)
-=======
-#!/usr/bin/env php
-<?php
->>>>>>> a1fc3d3 (Handle PHP builds without STDOUT constant)
+
 $root = dirname(__DIR__);
 $rii = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root));
 $pattern = "/->\s*prepare\s*\(\s*([\"'])(.*?)\1/s";
@@ -40,21 +32,11 @@ foreach ($rii as $file) {
             continue;
         }
         $offset = $match[1];
-        $line = substr_count(substr($code, 0, $offset), "\\n") + 1;
+        $line = substr_count(substr($code, 0, $offset), "\n") + 1;
         $results[] = [$rel, $line, trim($sql)];
     }
 }
-<<<<<<< HEAD
-<<<<<<< HEAD
-if (!$results) {
-    fwrite(STDOUT, "No mixed named/positional parameters found." . PHP_EOL);
-    exit(0);
-}
-foreach ($results as [$file, $line, $sql]) {
-    fwrite(STDOUT, sprintf("%s:%d\n%s\n\n", $file, $line, $sql));
-=======
-=======
->>>>>>> a1fc3d3 (Handle PHP builds without STDOUT constant)
+
 if (!function_exists('writeOut')) {
     function writeOut(string $message): void
     {
@@ -79,9 +61,5 @@ if (!$results) {
 }
 foreach ($results as [$file, $line, $sql]) {
     writeOut(sprintf("%s:%d\n%s\n\n", $file, $line, $sql));
-<<<<<<< HEAD
->>>>>>> a1fc3d3 (Handle PHP builds without STDOUT constant)
-=======
->>>>>>> a1fc3d3 (Handle PHP builds without STDOUT constant)
 }
 exit(1);

--- a/tools/scan_oaci_estacion.php
+++ b/tools/scan_oaci_estacion.php
@@ -1,12 +1,7 @@
 #!/usr/bin/env php
 <?php
-<<<<<<< HEAD
-<<<<<<< HEAD
 declare(strict_types=1);
-=======
->>>>>>> a1fc3d3 (Handle PHP builds without STDOUT constant)
-=======
->>>>>>> a1fc3d3 (Handle PHP builds without STDOUT constant)
+
 $root = dirname(__DIR__);
 $rii = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root));
 $hits = [];
@@ -32,15 +27,34 @@ foreach ($rii as $file) {
     }
     foreach ($matches[0] as $match) {
         $offset = $match[1];
-        $line = substr_count(substr($code, 0, $offset), "\\n") + 1;
+        $line = substr_count(substr($code, 0, $offset), "\n") + 1;
         $hits[] = [$rel, $line];
     }
 }
+
+if (!function_exists('writeOut')) {
+    function writeOut(string $message): void
+    {
+        if (defined('STDOUT')) {
+            fwrite(STDOUT, $message);
+            return;
+        }
+        // Some PHP builds (e.g. cgi-fcgi) do not expose STDOUT.
+        $handle = fopen('php://output', 'wb');
+        if ($handle === false) {
+            echo $message;
+            return;
+        }
+        fwrite($handle, $message);
+        fclose($handle);
+    }
+}
+
 if (!$hits) {
-    fwrite(STDOUT, "No e.oaci usages found." . PHP_EOL);
+    writeOut("No e.oaci usages found." . PHP_EOL);
     exit(0);
 }
 foreach ($hits as [$file, $line]) {
-    fwrite(STDOUT, sprintf("%s:%d -> revisar, usar e.estacion + JOIN estaciones\n", $file, $line));
+    writeOut(sprintf("%s:%d -> revisar, usar e.estacion + JOIN estaciones\n", $file, $line));
 }
 exit(1);


### PR DESCRIPTION
## Summary
- restore the shebang and add strict typing to the scan helper scripts
- share a writeOut helper that falls back to php://output when STDOUT is unavailable
- ensure the mixed-params and oaci scanners report through the helper consistently

## Testing
- php -l tools/scan_mixed_params.php
- php -l tools/scan_oaci_estacion.php

------
https://chatgpt.com/codex/tasks/task_e_68d360260d88832ba8b9b84dd5a5bb99