### PR TITLE
Fix PECOS/TXT edit API and unify action buttons

### DIFF
--- a/api/pecos_get.php
+++ b/api/pecos_get.php
@@ -1,6 +1,9 @@
 <?php
 declare(strict_types=1);
-require_once __DIR__ . '/bootstrap.php';// Encabezados base para JSON y evitar cacheado por proxies
+
+require_once __DIR__ . '/bootstrap.php';
+
+// Encabezados base para JSON y evitar cacheado por proxies
 header('Content-Type: application/json; charset=utf-8');
 header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
 header('Pragma: no-cache');
@@ -8,12 +11,13 @@ header('Pragma: no-cache');
 $ROOT = dirname(__DIR__); // …/unificado
 
 require_once $ROOT . '/lib/session.php';
-session_boot();                         // inicia sesión con cookie domain .ctareig.com
+session_boot(); // inicia sesión con cookie domain .ctareig.com
 
 require_once $ROOT . '/lib/db.php';
 require_once $ROOT . '/lib/auth.php';
 // NO require guard.php aquí: las APIs usan require_auth_api()
 
+$pdo = db();
 $u = require_auth_api();
 
 // api/pecos_get.php?control=XXXX&year=YYYY
@@ -21,16 +25,28 @@ $u = require_auth_api();
 $control = (int)($_GET['control'] ?? 0);
 $year = (int)($_GET['year'] ?? date('Y'));
 
-$st=$pdo->prepare("SELECT e.estacion, es.oaci FROM empleados e LEFT JOIN estaciones es ON es.id_estacion=e.estacion WHERE e.control=? LIMIT 1");
-$st->execute([$control]); $row=$st->fetch();
-if (!$row || (empty($row['oaci']) || !can_view_station($pdo, $row['oaci']))) { http_response_code(403); exit; }
-
-$st=$pdo->prepare("SELECT * FROM pecos WHERE control=? AND year=? LIMIT 1");
-$st->execute([$control, $year]); $r=$st->fetch();
-if (!$r) {
-  $pdo->prepare("INSERT INTO pecos (control,year,dia1,dia2,dia3,dia4,dia5,dia6,dia7,dia8,dia9,dia10,dia11,dia12)
-                 VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)")
-      ->execute([$control,$year,'0','0','0','0','0','0','0','0','0','0','0','0']);
-  $st->execute([$control, $year]); $r=$st->fetch();
+$st = $pdo->prepare('SELECT e.estacion, es.oaci
+                        FROM empleados e
+                        LEFT JOIN estaciones es ON es.id_estacion = e.estacion
+                       WHERE e.control = ?
+                       LIMIT 1');
+$st->execute([$control]);
+$row = $st->fetch();
+if (!$row || empty($row['oaci']) || !can_view_station($pdo, (string)$row['oaci'])) {
+    http_response_code(403);
+    exit;
 }
-header('Content-Type: application/json'); echo json_encode($r);
+
+$st = $pdo->prepare('SELECT * FROM pecos WHERE control = ? AND year = ? LIMIT 1');
+$st->execute([$control, $year]);
+$record = $st->fetch();
+
+if (!$record) {
+    $pdo->prepare('INSERT INTO pecos (control,year,dia1,dia2,dia3,dia4,dia5,dia6,dia7,dia8,dia9,dia10,dia11,dia12)
+                         VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)')
+        ->execute([$control, $year, '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0']);
+    $st->execute([$control, $year]);
+    $record = $st->fetch();
+}
+
+echo json_encode($record, JSON_UNESCAPED_UNICODE);

--- a/api/txt_get.php
+++ b/api/txt_get.php
@@ -1,6 +1,9 @@
 <?php
 declare(strict_types=1);
-require_once __DIR__ . '/bootstrap.php';// Encabezados base para JSON y evitar cacheado por proxies
+
+require_once __DIR__ . '/bootstrap.php';
+
+// Encabezados base para JSON y evitar cacheado por proxies
 header('Content-Type: application/json; charset=utf-8');
 header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
 header('Pragma: no-cache');
@@ -8,12 +11,13 @@ header('Pragma: no-cache');
 $ROOT = dirname(__DIR__); // …/unificado
 
 require_once $ROOT . '/lib/session.php';
-session_boot();                         // inicia sesión con cookie domain .ctareig.com
+session_boot(); // inicia sesión con cookie domain .ctareig.com
 
 require_once $ROOT . '/lib/db.php';
 require_once $ROOT . '/lib/auth.php';
 // NO require guard.php aquí: las APIs usan require_auth_api()
 
+$pdo = db();
 $u = require_auth_api();
 
 // api/txt_get.php?control=XXXX&year=YYYY
@@ -21,15 +25,28 @@ $u = require_auth_api();
 $control = (int)($_GET['control'] ?? 0);
 $year = (int)($_GET['year'] ?? date('Y'));
 
-$st=$pdo->prepare("SELECT e.estacion, es.oaci FROM empleados e LEFT JOIN estaciones es ON es.id_estacion=e.estacion WHERE e.control=? LIMIT 1");
-$st->execute([$control]); $row=$st->fetch();
-if (!$row || (empty($row['oaci']) || !can_view_station($pdo, $row['oaci']))) { http_response_code(403); exit; }
-
-$st=$pdo->prepare("SELECT * FROM txt WHERE control=? AND year=? LIMIT 1");
-$st->execute([$control, $year]); $r=$st->fetch();
-if (!$r) {
-  $pdo->prepare("INSERT INTO txt (control,year,js,vs,dm,ds,muert,ono) VALUES (?,?,?,?,?,?,?,?)")
-      ->execute([$control,$year,'0','0','0','0','0','0']);
-  $st->execute([$control, $year]); $r=$st->fetch();
+$st = $pdo->prepare('SELECT e.estacion, es.oaci
+                        FROM empleados e
+                        LEFT JOIN estaciones es ON es.id_estacion = e.estacion
+                       WHERE e.control = ?
+                       LIMIT 1');
+$st->execute([$control]);
+$row = $st->fetch();
+if (!$row || empty($row['oaci']) || !can_view_station($pdo, (string)$row['oaci'])) {
+    http_response_code(403);
+    exit;
 }
-header('Content-Type: application/json'); echo json_encode($r);
+
+$st = $pdo->prepare('SELECT * FROM txt WHERE control = ? AND year = ? LIMIT 1');
+$st->execute([$control, $year]);
+$record = $st->fetch();
+
+if (!$record) {
+    $pdo->prepare('INSERT INTO txt (control,year,js,vs,dm,ds,muert,ono)
+                         VALUES (?,?,?,?,?,?,?,?)')
+        ->execute([$control, $year, '0', '0', '0', '0', '0', '0']);
+    $st->execute([$control, $year]);
+    $record = $st->fetch();
+}
+
+echo json_encode($record, JSON_UNESCAPED_UNICODE);

--- a/public/assets/prestaciones.js
+++ b/public/assets/prestaciones.js
@@ -281,16 +281,16 @@ const API_BASE = (window.API_BASE || '/api/').replace(/\/+$/, '') + '/';
     const tbody = table.tBodies[0];
     tbody.innerHTML = '';
     if (!rows.length) {
-      clearTable(table, 15, 'Sin datos…');
+      clearTable(table, 14, 'Sin datos…');
       return;
     }
     rows.forEach((row) => {
       const tr = document.createElement('tr');
+      const actionDetail = { ...row, control: state.personaControl };
       tr.innerHTML = `
         <td>${row.year}</td>
-        ${Array.from({ length: 12 }, (_, i) => `<td class="text-center">${row['dia' + (i + 1)] ?? '0'}</td>`).join('')}
-        <td class="nowrap"><button class="btn btn-sm btn-outline-primary" data-prest-action="edit" data-prest-type="pecos" data-prest-scope="persona" data-prest-control="${state.personaControl}" data-prest-year="${row.year}">Editar</button></td>
-        <td class="nowrap"><button class="btn btn-sm btn-outline-danger" data-prest-action="delete" data-prest-type="pecos" data-prest-scope="persona" data-prest-control="${state.personaControl}" data-prest-year="${row.year}">Eliminar</button></td>
+        ${Array.from({ length: 12 }, (_, i) => `<td class="text-center">${row[`dia${i + 1}`] ?? '0'}</td>`).join('')}
+        <td class="nowrap">${renderActionCell('persona', 'pecos', actionDetail)}</td>
       `;
       tbody.appendChild(tr);
     });
@@ -309,12 +309,12 @@ const API_BASE = (window.API_BASE || '/api/').replace(/\/+$/, '') + '/';
     const targetYear = data.year ?? state.year;
     rows.forEach((row) => {
       const tr = document.createElement('tr');
+      const actionDetail = { ...row, year: targetYear };
       tr.innerHTML = `
         <td class="nowrap">${row.oaci || ''}</td>
         <td class="nowrap">${formatControl(row.control)} · ${row.nombres || ''}</td>
-        ${Array.from({ length: 12 }, (_, i) => `<td class="text-center">${row['dia' + (i + 1)] ?? '0'}</td>`).join('')}
-        <td class="nowrap"><button class="btn btn-sm btn-outline-primary" data-prest-action="edit" data-prest-type="pecos" data-prest-scope="anio" data-prest-control="${row.control}" data-prest-year="${targetYear}">Editar</button></td>
-        <td class="nowrap"><button class="btn btn-sm btn-outline-danger" data-prest-action="delete" data-prest-type="pecos" data-prest-scope="anio" data-prest-control="${row.control}" data-prest-year="${targetYear}">Eliminar</button></td>
+        ${Array.from({ length: 12 }, (_, i) => `<td class="text-center">${row[`dia${i + 1}`] ?? '0'}</td>`).join('')}
+        <td class="nowrap">${renderActionCell('anio', 'pecos', actionDetail)}</td>
       `;
       tbody.appendChild(tr);
     });
@@ -327,11 +327,12 @@ const API_BASE = (window.API_BASE || '/api/').replace(/\/+$/, '') + '/';
     const tbody = table.tBodies[0];
     tbody.innerHTML = '';
     if (!rows.length) {
-      clearTable(table, 10, 'Sin datos…');
+      clearTable(table, 9, 'Sin datos…');
       return;
     }
     rows.forEach((row) => {
       const tr = document.createElement('tr');
+      const actionDetail = { ...row, control: state.personaControl };
       tr.innerHTML = `
         <td>${row.year}</td>
         <td class="text-center">${row.js ?? '0'}</td>
@@ -341,8 +342,7 @@ const API_BASE = (window.API_BASE || '/api/').replace(/\/+$/, '') + '/';
         <td class="text-center">${row.muert ?? '0'}</td>
         <td class="text-center">${row.ono ?? '0'}</td>
         <td>${row.fnac || ''}</td>
-        <td class="nowrap"><button class="btn btn-sm btn-outline-primary" data-prest-action="edit" data-prest-type="txt" data-prest-scope="persona" data-prest-control="${state.personaControl}" data-prest-year="${row.year}">Editar</button></td>
-        <td class="nowrap"><button class="btn btn-sm btn-outline-danger" data-prest-action="delete" data-prest-type="txt" data-prest-scope="persona" data-prest-control="${state.personaControl}" data-prest-year="${row.year}">Eliminar</button></td>
+        <td class="nowrap">${renderActionCell('persona', 'txt', actionDetail)}</td>
       `;
       tbody.appendChild(tr);
     });
@@ -355,12 +355,13 @@ const API_BASE = (window.API_BASE || '/api/').replace(/\/+$/, '') + '/';
     const tbody = table.tBodies[0];
     tbody.innerHTML = '';
     if (!rows.length) {
-      clearTable(table, 11, 'Sin datos…');
+      clearTable(table, 10, 'Sin datos…');
       return;
     }
     const targetYear = data.year ?? state.year;
     rows.forEach((row) => {
       const tr = document.createElement('tr');
+      const actionDetail = { ...row, year: targetYear };
       tr.innerHTML = `
         <td class="nowrap">${row.oaci || ''}</td>
         <td class="nowrap">${formatControl(row.control)} · ${row.nombres || ''}</td>
@@ -371,8 +372,7 @@ const API_BASE = (window.API_BASE || '/api/').replace(/\/+$/, '') + '/';
         <td class="text-center">${row.muert ?? '0'}</td>
         <td class="text-center">${row.ono ?? '0'}</td>
         <td>${row.fnac || ''}</td>
-        <td class="nowrap"><button class="btn btn-sm btn-outline-primary" data-prest-action="edit" data-prest-type="txt" data-prest-scope="anio" data-prest-control="${row.control}" data-prest-year="${targetYear}">Editar</button></td>
-        <td class="nowrap"><button class="btn btn-sm btn-outline-danger" data-prest-action="delete" data-prest-type="txt" data-prest-scope="anio" data-prest-control="${row.control}" data-prest-year="${targetYear}">Eliminar</button></td>
+        <td class="nowrap">${renderActionCell('anio', 'txt', actionDetail)}</td>
       `;
       tbody.appendChild(tr);
     });
@@ -397,30 +397,41 @@ const API_BASE = (window.API_BASE || '/api/').replace(/\/+$/, '') + '/';
     return { vac1, vac2 };
   }
 
-  function renderActionCell(scope, type, row) {
-    const controlValue = row.control ?? row.control_fmt ?? '';
-    const control = String(controlValue ?? '');
-    const attrs = `data-prest-type="${type}" data-prest-scope="${scope}" data-prest-control="${control}"`;
-    const yearValue = row.year ?? '';
-    const yearAttr = yearValue !== '' ? ` data-prest-year="${yearValue}"` : '';
+  function serializeActionAttributes(pairs) {
+    return pairs
+      .filter(([, value]) => value !== undefined && value !== null && String(value) !== '')
+      .map(([key, value]) => `${key}="${String(value)}"`)
+      .join(' ');
+  }
+
+  function renderActionCell(scope, type, row = {}) {
     const flags = renderFlags(row.flags);
-    if (type === 'vac') {
-      return `
-        <div class="d-inline-flex align-items-center gap-2 flex-wrap">
-          ${flags ? `<span class="text-nowrap">${flags}</span>` : ''}
-          <div class="vac-action-pill">
-            <button type="button" class="btn btn-add" data-prest-action="add" ${attrs}${yearAttr}>Agregar</button>
-            <button type="button" class="btn btn-edit" data-prest-action="edit" ${attrs}${yearAttr}>Editar</button>
-          </div>
-        </div>
-      `;
+    const controlValue = row.control ?? row.control_fmt ?? '';
+    const yearValue = row.year ?? '';
+    const idValue = row.id ?? row.Id ?? row.ID ?? '';
+
+    const basePairs = [
+      ['data-prest-type', type],
+      ['data-prest-scope', scope],
+      ['data-prest-control', controlValue],
+    ];
+    if (String(yearValue) !== '') {
+      basePairs.push(['data-prest-year', yearValue]);
     }
+
+    const addAttrs = serializeActionAttributes(basePairs);
+    const editPairs = basePairs.slice();
+    if (String(idValue) !== '') {
+      editPairs.push(['data-prest-id', idValue]);
+    }
+    const editAttrs = serializeActionAttributes(editPairs);
+
     return `
       <div class="d-inline-flex align-items-center gap-2 flex-wrap">
         ${flags ? `<span class="text-nowrap">${flags}</span>` : ''}
-        <div class="btn-group btn-group-sm">
-          <button type="button" class="btn btn-outline-primary" data-prest-action="edit" ${attrs}${yearAttr}>Editar</button>
-          <button type="button" class="btn btn-outline-danger" data-prest-action="delete" ${attrs}${yearAttr}>Eliminar</button>
+        <div class="vac-action-pill">
+          <button type="button" class="btn btn-add" data-prest-action="add" ${addAttrs}>Agregar</button>
+          <button type="button" class="btn btn-edit" data-prest-action="edit" ${editAttrs}>Editar</button>
         </div>
       </div>
     `;
@@ -444,6 +455,7 @@ const API_BASE = (window.API_BASE || '/api/').replace(/\/+$/, '') + '/';
     rows.forEach((row) => {
       const { vac1, vac2 } = splitVacLeft(row.dias_left);
       const tr = document.createElement('tr');
+      const actionDetail = { ...row, control: row.control ?? state.personaControl };
       tr.innerHTML = `
         <td class="text-center">${row.year}</td>
         <td class="text-center">${row.ant_asig}</td>
@@ -452,7 +464,7 @@ const API_BASE = (window.API_BASE || '/api/').replace(/\/+$/, '') + '/';
         <td class="text-center">${vac2}</td>
         <td class="text-center">${row.ant_usados}</td>
         <td class="text-center">${row.pr_usados}</td>
-        <td class="nowrap">${renderActionCell('persona', 'vac', row)}</td>
+        <td class="nowrap">${renderActionCell('persona', 'vac', actionDetail)}</td>
       `;
       tbody.appendChild(tr);
     });
@@ -682,7 +694,8 @@ const API_BASE = (window.API_BASE || '/api/').replace(/\/+$/, '') + '/';
       ensureModal()?.show();
       return;
     }
-    setModalTitle(formatYearTitle('Editar PECO', detail.year));
+    const titlePrefix = detail.action === 'add' ? 'Registrar PECO' : 'Editar PECO';
+    setModalTitle(formatYearTitle(titlePrefix, detail.year));
     setModalMessage('Cargando registro…', 'info');
     ensureModal()?.show();
     try {
@@ -719,7 +732,8 @@ const API_BASE = (window.API_BASE || '/api/').replace(/\/+$/, '') + '/';
       ensureModal()?.show();
       return;
     }
-    setModalTitle(formatYearTitle('Editar Tiempo x Tiempo', detail.year));
+    const titlePrefix = detail.action === 'add' ? 'Registrar Tiempo x Tiempo' : 'Editar Tiempo x Tiempo';
+    setModalTitle(formatYearTitle(titlePrefix, detail.year));
     setModalMessage('Cargando registro…', 'info');
     ensureModal()?.show();
     try {
@@ -1065,9 +1079,20 @@ const API_BASE = (window.API_BASE || '/api/').replace(/\/+$/, '') + '/';
   }
 
   function openIncEdit(detail) {
-    setModalTitle('Editar incapacidad');
+    const isAdd = detail.action === 'add';
+    setModalTitle(isAdd ? 'Registrar incapacidad' : 'Editar incapacidad');
     ensureModal()?.show();
-    const parsed = extractIncRow(detail);
+    const parsed = isAdd
+      ? {
+          year: detail.year || '',
+          folio: '',
+          inicia: '',
+          termina: '',
+          dias: '',
+          umf: '',
+          diag: '',
+        }
+      : extractIncRow(detail);
     const fields = [
       { type: 'hidden', name: 'id', value: detail.id || '0' },
       { type: 'hidden', name: 'control', value: detail.control || '' },
@@ -1298,12 +1323,17 @@ const API_BASE = (window.API_BASE || '/api/').replace(/\/+$/, '') + '/';
     const tbody = table.tBodies[0];
     tbody.innerHTML = '';
     if (!rows.length) {
-      clearTable(table, 9, 'Sin datos…');
+      clearTable(table, 8, 'Sin datos…');
       return;
     }
     rows.forEach((row) => {
       const tr = document.createElement('tr');
       const yearText = row.INICIA && row.INICIA.includes('/') ? row.INICIA.split('/').pop() : '';
+      const actionDetail = {
+        control: state.personaControl,
+        year: yearText || '',
+        id: row.Id ?? row.id ?? row.ID ?? '',
+      };
       tr.innerHTML = `
         <td>${yearText || ''}</td>
         <td>${row.FOLIO || ''}</td>
@@ -1312,8 +1342,7 @@ const API_BASE = (window.API_BASE || '/api/').replace(/\/+$/, '') + '/';
         <td class="text-center">${row.DIAS ?? 0}</td>
         <td>${row.UMF || ''}</td>
         <td>${row.DIAGNOSTICO || ''}</td>
-        <td class="nowrap"><button class="btn btn-sm btn-outline-primary" data-prest-action="edit" data-prest-type="inc" data-prest-scope="persona" data-prest-control="${state.personaControl}" data-prest-id="${row.Id ?? row.id ?? ''}" data-prest-year="${yearText || ''}">Editar</button></td>
-        <td class="nowrap"><button class="btn btn-sm btn-outline-danger" data-prest-action="delete" data-prest-type="inc" data-prest-scope="persona" data-prest-control="${state.personaControl}" data-prest-id="${row.Id ?? row.id ?? ''}" data-prest-year="${yearText || ''}">Eliminar</button></td>
+        <td class="nowrap">${renderActionCell('persona', 'inc', actionDetail)}</td>
       `;
       tbody.appendChild(tr);
     });
@@ -1326,12 +1355,17 @@ const API_BASE = (window.API_BASE || '/api/').replace(/\/+$/, '') + '/';
     const tbody = table.tBodies[0];
     tbody.innerHTML = '';
     if (!rows.length) {
-      clearTable(table, 10, 'Sin datos…');
+      clearTable(table, 9, 'Sin datos…');
       return;
     }
     const targetYear = data.year ?? state.year;
     rows.forEach((row) => {
       const tr = document.createElement('tr');
+      const actionDetail = {
+        ...row,
+        year: targetYear,
+        id: row.Id ?? row.id ?? row.ID ?? '',
+      };
       tr.innerHTML = `
         <td class="nowrap">${row.oaci || ''}</td>
         <td class="nowrap">${formatControl(row.control)} · ${row.nombres || ''}</td>
@@ -1341,8 +1375,7 @@ const API_BASE = (window.API_BASE || '/api/').replace(/\/+$/, '') + '/';
         <td class="text-center">${row.DIAS ?? 0}</td>
         <td>${row.UMF || ''}</td>
         <td>${row.DIAGNOSTICO || ''}</td>
-        <td class="nowrap"><button class="btn btn-sm btn-outline-primary" data-prest-action="edit" data-prest-type="inc" data-prest-scope="anio" data-prest-control="${row.control}" data-prest-year="${targetYear}" data-prest-id="${row.Id ?? row.id ?? ''}">Editar</button></td>
-        <td class="nowrap"><button class="btn btn-sm btn-outline-danger" data-prest-action="delete" data-prest-type="inc" data-prest-scope="anio" data-prest-control="${row.control}" data-prest-year="${targetYear}" data-prest-id="${row.Id ?? row.id ?? ''}">Eliminar</button></td>
+        <td class="nowrap">${renderActionCell('anio', 'inc', actionDetail)}</td>
       `;
       tbody.appendChild(tr);
     });

--- a/public/prestaciones.php
+++ b/public/prestaciones.php
@@ -373,8 +373,8 @@ if (!$u) {
               <div class="card-header fw-semibold">Días Economicos (PECO) — Vista por Persona</div>
               <div class="card-body sticky-wrap">
                 <table class="table table-sm table-striped table-hover align-middle" id="tblPecosPersona">
-                  <thead><tr><th>Año</th><th>D-01</th><th>D-02</th><th>D-03</th><th>D-04</th><th>D-05</th><th>D-06</th><th>D-07</th><th>D-08</th><th>D-09</th><th>D-10</th><th>D-11</th><th>D-12</th><th>Editar</th><th>Eliminar</th></tr></thead>
-                  <tbody><tr><td colspan="15" class="text-secondary">Seleccione un trabajador…</td></tr></tbody>
+                  <thead><tr><th>Año</th><th>D-01</th><th>D-02</th><th>D-03</th><th>D-04</th><th>D-05</th><th>D-06</th><th>D-07</th><th>D-08</th><th>D-09</th><th>D-10</th><th>D-11</th><th>D-12</th><th>Acciones</th></tr></thead>
+                  <tbody><tr><td colspan="14" class="text-secondary">Seleccione un trabajador…</td></tr></tbody>
                 </table>
               </div>
             </div>
@@ -384,7 +384,7 @@ if (!$u) {
               <div class="card-header fw-semibold">Días Economicos (PECO) — Vista por Año</div>
               <div class="card-body sticky-wrap">
                 <table class="table table-sm table-striped table-hover align-middle" id="tblPecosYear">
-                  <thead><tr><th>Estación</th><th>Trabajador</th><th>D-01</th><th>D-02</th><th>D-03</th><th>D-04</th><th>D-05</th><th>D-06</th><th>D-07</th><th>D-08</th><th>D-09</th><th>D-10</th><th>D-11</th><th>D-12</th><th>Editar</th><th>Eliminar</th></tr></thead>
+                  <thead><tr><th>Estación</th><th>Trabajador</th><th>D-01</th><th>D-02</th><th>D-03</th><th>D-04</th><th>D-05</th><th>D-06</th><th>D-07</th><th>D-08</th><th>D-09</th><th>D-10</th><th>D-11</th><th>D-12</th><th>Acciones</th></tr></thead>
                   <tbody><tr><td class="text-secondary">Seleccione año…</td></tr></tbody>
                 </table>
               </div>
@@ -399,8 +399,8 @@ if (!$u) {
               <div class="card-header fw-semibold">Días Acumulables — Vista por Persona</div>
               <div class="card-body sticky-wrap">
                 <table class="table table-sm table-striped table-hover align-middle" id="tblTxtPersona">
-                  <thead><tr><th>Año</th><th>Jue. Santo</th><th>Vie. Santo</th><th>D. Madres</th><th>SENEAM/ATC</th><th>D. Muertos</th><th>Onomástico</th><th>Fecha Nac.</th><th>Editar</th><th>Eliminar</th></tr></thead>
-                  <tbody><tr><td colspan="10" class="text-secondary">Seleccione un trabajador…</td></tr></tbody>
+                  <thead><tr><th>Año</th><th>Jue. Santo</th><th>Vie. Santo</th><th>D. Madres</th><th>SENEAM/ATC</th><th>D. Muertos</th><th>Onomástico</th><th>Fecha Nac.</th><th>Acciones</th></tr></thead>
+                  <tbody><tr><td colspan="9" class="text-secondary">Seleccione un trabajador…</td></tr></tbody>
                 </table>
               </div>
             </div>
@@ -410,7 +410,7 @@ if (!$u) {
               <div class="card-header fw-semibold">Días Acumulables — Vista por Año</div>
               <div class="card-body sticky-wrap">
                 <table class="table table-sm table-striped table-hover align-middle" id="tblTxtYear">
-                  <thead><tr><th>Estación</th><th>Trabajador</th><th>Jue. Santo</th><th>Vie. Santo</th><th>D. Madres</th><th>SENEAM/ATC</th><th>D. Muertos</th><th>Onomástico</th><th>Fecha Nac.</th><th>Editar</th><th>Eliminar</th></tr></thead>
+                  <thead><tr><th>Estación</th><th>Trabajador</th><th>Jue. Santo</th><th>Vie. Santo</th><th>D. Madres</th><th>SENEAM/ATC</th><th>D. Muertos</th><th>Onomástico</th><th>Fecha Nac.</th><th>Acciones</th></tr></thead>
                   <tbody><tr><td class="text-secondary">Seleccione año…</td></tr></tbody>
                 </table>
               </div>
@@ -451,8 +451,8 @@ if (!$u) {
               <div class="card-header fw-semibold">Incapacidades — Vista por Persona</div>
               <div class="card-body sticky-wrap">
                 <table class="table table-sm table-striped table-hover align-middle" id="tblIncPersona">
-                  <thead><tr><th>Año</th><th>Folio</th><th>Inicia</th><th>Termina</th><th>Días</th><th>UMF</th><th>Diag.</th><th>Editar</th><th>Eliminar</th></tr></thead>
-                  <tbody><tr><td colspan="9" class="text-secondary">Seleccione un trabajador…</td></tr></tbody>
+                  <thead><tr><th>Año</th><th>Folio</th><th>Inicia</th><th>Termina</th><th>Días</th><th>UMF</th><th>Diag.</th><th>Acciones</th></tr></thead>
+                  <tbody><tr><td colspan="8" class="text-secondary">Seleccione un trabajador…</td></tr></tbody>
                 </table>
               </div>
             </div>
@@ -462,7 +462,7 @@ if (!$u) {
               <div class="card-header fw-semibold">Incapacidades — Vista por Año</div>
               <div class="card-body sticky-wrap">
                 <table class="table table-sm table-striped table-hover align-middle" id="tblIncYear">
-                  <thead><tr><th>Estación</th><th>Trabajador</th><th>Folio</th><th>Inicia</th><th>Termina</th><th>Días</th><th>UMF</th><th>Diag.</th><th>Editar</th><th>Eliminar</th></tr></thead>
+                  <thead><tr><th>Estación</th><th>Trabajador</th><th>Folio</th><th>Inicia</th><th>Termina</th><th>Días</th><th>UMF</th><th>Diag.</th><th>Acciones</th></tr></thead>
                   <tbody><tr><td class="text-secondary">Seleccione año…</td></tr></tbody>
                 </table>
               </div>


### PR DESCRIPTION
## Summary
- ensure the PECOS and TXT edit endpoints bootstrap the database connection before using it and keep inserting default records when needed
- restyle prestaciones action cells to reuse the vacaciones add/edit pill, update modal titles for add flows and remove delete buttons from PECOS/TXT/Inc tables
- adjust prestaciones table headers/placeholders to match the new two-button action layout

## Testing
- tools/run_php_lint.sh

------
https://chatgpt.com/codex/tasks/task_e_68d39580c840832b8420b5a9078965e4